### PR TITLE
Fixes for macOS, Big Sur and gfortran-10

### DIFF
--- a/W/Makefile
+++ b/W/Makefile
@@ -12,7 +12,16 @@ ANALYSIS=SC
 #STATIC= -static
 #
 ifeq ("$(COMPILER)","gfortran")	
-F77= gfortran -fno-automatic 	
+FMISMATCH=
+GFORTRAN_VERION = $(shell gfortran --version | head -1 | rev | cut -d " " -f1 | rev)
+version_tuple := $(subst ., ,$(GFORTRAN_VERION:%=%))
+GFORTRAN_VERION_MAJOR := $(word 1,$(version_tuple))
+GFORTRAN_VERION_MINOR := $(word 2,$(version_tuple))
+GFORTRAN_VERION_PATCH := $(word 3,$(version_tuple))
+ifeq ($(GFORTRAN_VERION_MAJOR), 10)
+FMISMATCH=-fallow-argument-mismatch
+endif
+F77= gfortran -fno-automatic $(FMISMATCH)
 ## -fbounds-check sometimes causes a weird error due to non-lazy evaluation
 ## of boolean in gfortran.
 #FFLAGS= -Wall -Wimplicit-interface -fbounds-check
@@ -54,7 +63,11 @@ OPT = -O3 #-fast
 #DEBUG= -debug -g
 endif
 
-
+SYSTEM=$(shell uname -s)
+STDLIBCPP=-lstdc++
+ifeq ("$(SYSTEM)", "Darwin")
+STDLIBCPP=-lc++
+endif
 
 PWD=$(shell pwd)
 WDNAME=$(shell basename $(PWD))
@@ -74,7 +87,7 @@ ifeq ("$(PDF)","lhapdf6")
 LHAPDF_CONFIG=lhapdf-config
 FJCXXFLAGS+= $(shell $(LHAPDF_CONFIG) --cxxflags)
 PDFPACK=lhapdf6if.o lhapdf6ifcc.o
-LIBSLHAPDF= -Wl,-rpath,$(shell $(LHAPDF_CONFIG) --libdir)  -L$(shell $(LHAPDF_CONFIG) --libdir) -lLHAPDF -lstdc++
+LIBSLHAPDF= -Wl,-rpath,$(shell $(LHAPDF_CONFIG) --libdir)  -L$(shell $(LHAPDF_CONFIG) --libdir) -lLHAPDF $(STDLIBCPP)
 LIBS+=$(LIBSLHAPDF)
 endif
 

--- a/Z/Makefile
+++ b/Z/Makefile
@@ -12,7 +12,16 @@ ANALYSIS=SC
 #STATIC= -static
 #
 ifeq ("$(COMPILER)","gfortran")	
-F77= gfortran -fno-automatic 	
+FMISMATCH=
+GFORTRAN_VERION = $(shell gfortran --version | head -1 | rev | cut -d " " -f1 | rev)
+version_tuple := $(subst ., ,$(GFORTRAN_VERION:%=%))
+GFORTRAN_VERION_MAJOR := $(word 1,$(version_tuple))
+GFORTRAN_VERION_MINOR := $(word 2,$(version_tuple))
+GFORTRAN_VERION_PATCH := $(word 3,$(version_tuple))
+ifeq ($(GFORTRAN_VERION_MAJOR), 10)
+FMISMATCH=-fallow-argument-mismatch
+endif
+F77= gfortran -fno-automatic $(FMISMATCH)
 ## -fbounds-check sometimes causes a weird error due to non-lazy evaluation
 ## of boolean in gfortran.
 #FFLAGS= -Wall -Wimplicit-interface -fbounds-check
@@ -52,7 +61,11 @@ OPT = -O3 #-fast
 #DEBUG= -debug -g
 endif
 
-
+SYSTEM=$(shell uname -s)
+STDLIBCPP=-lstdc++
+ifeq ("$(SYSTEM)", "Darwin")
+STDLIBCPP=-lc++
+endif
 
 PWD=$(shell pwd)
 WDNAME=$(shell basename $(PWD))
@@ -69,7 +82,7 @@ ifeq ("$(PDF)","lhapdf")
 LHAPDF_CONFIG=lhapdf-config
 PDFPACK=lhapdf6if.o lhapdf6ifcc.o
 FJCXXFLAGS+= $(shell $(LHAPDF_CONFIG) --cxxflags)
-LIBSLHAPDF= -Wl,-rpath,$(shell $(LHAPDF_CONFIG) --libdir)  -L$(shell $(LHAPDF_CONFIG) --libdir) -lLHAPDF -lstdc++
+LIBSLHAPDF= -Wl,-rpath,$(shell $(LHAPDF_CONFIG) --libdir)  -L$(shell $(LHAPDF_CONFIG) --libdir) -lLHAPDF $(STDLIBCPP)
 ifeq  ("$(STATIC)","-static") 
 ## If LHAPDF has been compiled with gfortran and you want to link it statically, you have to include
 ## libgfortran as well. The same holds for libstdc++. 

--- a/bbinit.f
+++ b/bbinit.f
@@ -506,7 +506,7 @@ c different grid iterations
      1        xgrid,xint,iret)
          if(iret.ne.0) then
             write(*,*) 'cannot find level '//prevtag//'gridinfo files'
-            call pwhg_exit()
+            call pwhg_exit(1)
          endif
       endif
 c The actual value of the grid is the one to be saved in the

--- a/dijet/Makefile
+++ b/dijet/Makefile
@@ -12,7 +12,16 @@ ANALYSIS=default
 #STATIC= -static
 #
 ifeq ("$(COMPILER)","gfortran")	
-F77= gfortran -fno-automatic 	
+FMISMATCH=
+GFORTRAN_VERION = $(shell gfortran --version | head -1 | rev | cut -d " " -f1 | rev)
+version_tuple := $(subst ., ,$(GFORTRAN_VERION:%=%))
+GFORTRAN_VERION_MAJOR := $(word 1,$(version_tuple))
+GFORTRAN_VERION_MINOR := $(word 2,$(version_tuple))
+GFORTRAN_VERION_PATCH := $(word 3,$(version_tuple))
+ifeq ($(GFORTRAN_VERION_MAJOR), 10)
+FMISMATCH=-fallow-argument-mismatch
+endif
+F77= gfortran -fno-automatic $(FMISMATCH)
 ## NOTE: -fbounds-check sometimes causes a compilation error
 ## due to non-lazy evaluation of boolean in gfortran.
 # FFLAGS= -Wall -Wimplicit-interface
@@ -42,6 +51,12 @@ OPT = -O3 #-fast
 #DEBUG= -debug -g
 endif
 
+SYSTEM=$(shell uname -s)
+STDLIBCPP=-lstdc++
+ifeq ("$(SYSTEM)", "Darwin")
+STDLIBCPP=-lc++
+endif
+
 OBJ=obj-$(COMPILER)
 
 PWD=$(shell pwd)
@@ -68,7 +83,7 @@ ifeq  ("$(STATIC)","-static")
 ## does perform this inclusion. The path has to be set by the user. 
  LIBGFORTRANPATH=/usr/lib/gcc/x86_64-redhat-linux/4.1.2
  LIBSTDCPP=/lib64
- LIBSLHAPDF+=  -L$(LIBGFORTRANPATH)  -lgfortranbegin -lgfortran -L$(LIBSTDCPP) -lstdc++
+ LIBSLHAPDF+=  -L$(LIBGFORTRANPATH)  -lgfortranbegin -lgfortran -L$(LIBSTDCPP) $(STDLIBCPP)
 endif
 LIBS+=$(LIBSLHAPDF)
 else
@@ -79,7 +94,7 @@ endif
 ifeq ("$(ANALYSIS)","default")
 ##To include Fastjet configuration uncomment the following lines. 
 FASTJET_CONFIG=$(shell which fastjet-config)
-LIBSFASTJET += $(shell $(FASTJET_CONFIG) --libs --plugins ) -lstdc++
+LIBSFASTJET += $(shell $(FASTJET_CONFIG) --libs --plugins ) $(STDLIBCPP)
 FJCXXFLAGS+= $(shell $(FASTJET_CONFIG) --cxxflags)
 PWHGANAL=pwhg_analysis.o pwhg_bookhist-multi.o  observables.o fastjetfortran.o
 ## Also add required Fastjet drivers to PWHGANAL (examples are reported)

--- a/hvq/Makefile
+++ b/hvq/Makefile
@@ -12,7 +12,16 @@ ANALYSIS=dummy
 #STATIC= -static
 #
 ifeq ("$(COMPILER)","gfortran")	
-F77= gfortran -fno-automatic 	
+FMISMATCH=
+GFORTRAN_VERION = $(shell gfortran --version | head -1 | rev | cut -d " " -f1 | rev)
+version_tuple := $(subst ., ,$(GFORTRAN_VERION:%=%))
+GFORTRAN_VERION_MAJOR := $(word 1,$(version_tuple))
+GFORTRAN_VERION_MINOR := $(word 2,$(version_tuple))
+GFORTRAN_VERION_PATCH := $(word 3,$(version_tuple))
+ifeq ($(GFORTRAN_VERION_MAJOR), 10)
+FMISMATCH=-fallow-argument-mismatch
+endif
+F77= gfortran -fno-automatic $(FMISMATCH)
 ## -fbounds-check sometimes causes a weird error due to non-lazy evaluation
 ## of boolean in gfortran.
 #FFLAGS= -Wall -Wimplicit-interface -fbounds-check
@@ -37,6 +46,12 @@ OPT = -O3 #-fast
 #DEBUG= -debug -g
 endif
 
+SYSTEM=$(shell uname -s)
+STDLIBCPP=-lstdc++
+ifeq ("$(SYSTEM)", "Darwin")
+STDLIBCPP=-lc++
+endif
+
 OBJ=obj-$(COMPILER)
 
 
@@ -55,7 +70,7 @@ ifeq ("$(PDF)","lhapdf")
 LHAPDF_CONFIG=lhapdf-config
 PDFPACK=lhapdf6if.o lhapdf6ifcc.o
 FJCXXFLAGS+= $(shell $(LHAPDF_CONFIG) --cxxflags)
-LIBSLHAPDF= -Wl,-rpath,$(shell $(LHAPDF_CONFIG) --libdir)  -L$(shell $(LHAPDF_CONFIG) --libdir) -lLHAPDF -lstdc++
+LIBSLHAPDF= -Wl,-rpath,$(shell $(LHAPDF_CONFIG) --libdir)  -L$(shell $(LHAPDF_CONFIG) --libdir) -lLHAPDF $(STDLIBCPP)
 ifeq  ("$(STATIC)","-static") 
 ## If LHAPDF has been compiled with gfortran and you want to link it statically, you have to include
 ## libgfortran as well. The same holds for libstdc++. 
@@ -63,7 +78,7 @@ ifeq  ("$(STATIC)","-static")
 ## does perform this inclusion. The path has to be set by the user. 
  LIBGFORTRANPATH=/usr/lib/gcc/x86_64-redhat-linux/4.1.2
  LIBSTDCPP=/lib64
- LIBSLHAPDF+=  -L$(LIBGFORTRANPATH)  -lgfortranbegin -lgfortran -L$(LIBSTDCPP) -lstdc++
+ LIBSLHAPDF+=  -L$(LIBGFORTRANPATH)  -lgfortranbegin -lgfortran -L$(LIBSTDCPP) $(STDLIBCPP)
 endif
 LIBS+=$(LIBSLHAPDF)
 else


### PR DESCRIPTION
gfortran-10:
- Add check for gfortran version
- Add "-fallow-argument-mismatch" in case
  of gfortran-10

macOS and Big Sur:
- add check for OS flavour
- link against "libc++" instead of
  "libstdc++" in case of Darwin OS flavour