### PR TITLE
Fix unbound return value

### DIFF
--- a/include/pwhg_io_interface.h
+++ b/include/pwhg_io_interface.h
@@ -45,6 +45,7 @@ c     -*- Fortran -*-
          function gzRewind(file) bind(C, NAME='gzrewind')
          use, intrinsic :: ISO_C_BINDING
          type(c_ptr), value :: file
+         integer(c_int) :: gzRewind
          end function
       end interface
       interface

--- a/zlibdummy.c
+++ b/zlibdummy.c
@@ -36,6 +36,7 @@ int gzputc(FILE *stream, int c) {
 }
 
 
-void gzrewind(FILE *stream) {
-  return rewind(stream);
+int gzrewind(FILE *stream) {
+  rewind(stream);
+  return 0;
 }


### PR DESCRIPTION
Return value not pass when binding to to C
interface, resulting in a crash in gzRewind
in most cases. Only visible when running
reweighting